### PR TITLE
style: Replace invalid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "author": "Matt Pocock <mattpocockvoice@gmail.com>",
-  "license": "GPL",
+  "license": "GPL-3.0",
   "devDependencies": {
     "@types/node": "^18.6.5",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
When doing a `yarn e n`, I get a warning to use a valid SPX license expression relating to line of package.json being "GPL".

According to the [documentation](https://spdx.org/licenses), "GPL" is an invalid license. We should probably change this to use the SPDX version to correctly reflect licensing.