### PR TITLE
chore: move "@types/express" to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,13 @@
     "": {
       "name": "beginners-typescript",
       "version": "1.0.0",
-      "license": "GPL",
+      "license": "GPL-3.0",
       "dependencies": {
-        "@types/express": "^4.17.13",
         "express": "^4.18.1",
         "zod": "^3.17.10"
       },
       "devDependencies": {
+        "@types/express": "^4.17.13",
         "@types/node": "^18.6.5",
         "chokidar": "^3.5.3",
         "cross-fetch": "^3.1.5",
@@ -23,6 +23,7 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -44,6 +45,7 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -51,6 +53,7 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -61,6 +64,7 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.30",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -70,22 +74,27 @@
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.6.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "*",
@@ -1221,6 +1230,7 @@
   "dependencies": {
     "@types/body-parser": {
       "version": "1.19.2",
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1239,12 +1249,14 @@
     },
     "@types/connect": {
       "version": "3.4.35",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
       "version": "4.17.13",
+      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -1254,6 +1266,7 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.30",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1261,19 +1274,24 @@
       }
     },
     "@types/mime": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "@types/node": {
-      "version": "18.6.5"
+      "version": "18.6.5",
+      "dev": true
     },
     "@types/qs": {
-      "version": "6.9.7"
+      "version": "6.9.7",
+      "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.15.0",
+      "dev": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Matt Pocock <mattpocockvoice@gmail.com>",
   "license": "GPL-3.0",
   "devDependencies": {
+    "@types/express": "^4.17.13",
     "@types/node": "^18.6.5",
     "chokidar": "^3.5.3",
     "cross-fetch": "^3.1.5",
@@ -18,7 +19,6 @@
     "s": "npm run solution"
   },
   "dependencies": {
-    "@types/express": "^4.17.13",
     "express": "^4.18.1",
     "zod": "^3.17.10"
   }


### PR DESCRIPTION
Just a minor change to remove "@types/express" from the dependencies list to devDependencies