### PR TITLE
Exit program upon exercise completion

### DIFF
--- a/scripts/exercise.js
+++ b/scripts/exercise.js
@@ -51,6 +51,7 @@ chokidar.watch(exerciseFile).on("all", (event, path) => {
       stdio: "inherit",
     });
     console.log("Typecheck complete. You finished the exercise!");
+    process.exit(0);
   } catch (e) {
     console.log("Failed. Try again!");
   }


### PR DESCRIPTION
It feels a little clunky to manually have to hit `Ctrl + C` after completing an exercise in order to move on to the next one. I think it would be better if the program exits upon completing each exercise to save users a couple keyboard clicks.