### PR TITLE
Small fixes

### DIFF
--- a/src/11-record.problem.ts
+++ b/src/11-record.problem.ts
@@ -26,7 +26,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should remove values from the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.1.ts
+++ b/src/11-record.solution.1.ts
@@ -26,7 +26,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should remove values from the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.2.ts
+++ b/src/11-record.solution.2.ts
@@ -28,7 +28,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should remove values from the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.3.ts
+++ b/src/11-record.solution.3.ts
@@ -30,7 +30,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should remove values from the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/18-function-types-with-promises.solution.ts
+++ b/src/18-function-types-with-promises.solution.ts
@@ -9,8 +9,8 @@ interface User {
 const createThenGetUser = async (
   createUser: () => Promise<string>,
   getUser: (id: string) => Promise<User>,
-): Promise<User> => {
-  const userId: string = await createUser();
+) => {
+  const userId = await createUser();
 
   const user = await getUser(userId);
 

--- a/src/18-function-types-with-promises.solution.ts
+++ b/src/18-function-types-with-promises.solution.ts
@@ -9,8 +9,8 @@ interface User {
 const createThenGetUser = async (
   createUser: () => Promise<string>,
   getUser: (id: string) => Promise<User>,
-) => {
-  const userId = await createUser();
+): Promise<User> => {
+  const userId: string = await createUser();
 
   const user = await getUser(userId);
 


### PR DESCRIPTION
### Changes
- Fixed typo in `11-record.problem` and `11-record.solutions` to -> from
- Cleaned up `Promise<User>` and `string` types from `18-function-types-with-promises.solution` because they are inferred. Slight difference is that we no longer enforce that exact return type.

### Screenshots
Before
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/61449927/195661259-e3bae6ea-b425-4c5b-a00f-cd4dadc819fa.png">

After:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/61449927/195660540-321af625-64c7-4fba-beda-d028aab95a95.png">

But:
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/61449927/195661427-eaf57791-a683-4923-a900-d0d39e43683f.png">
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/61449927/195661571-f1dcc7e5-93cb-40a6-b3a1-adc21d237f13.png">