### PR TITLE
exit process after running the exercies script

### DIFF
--- a/scripts/exercise.js
+++ b/scripts/exercise.js
@@ -51,7 +51,9 @@ chokidar.watch(exerciseFile).on("all", (event, path) => {
       stdio: "inherit",
     });
     console.log("Typecheck complete. You finished the exercise!");
+    process.exit();
   } catch (e) {
     console.log("Failed. Try again!");
+    process.exit(1);
   }
 });


### PR DESCRIPTION
After the `exercise.js` script is done, the process never quits (dunno if it's just a windows thing). I added calls to `process.exit()` at the end to force the node script to quit.