### PR TITLE
Fix tests definition in 11-record task

### DIFF
--- a/src/11-record.problem.ts
+++ b/src/11-record.problem.ts
@@ -18,7 +18,7 @@ const createCache = () => {
   };
 };
 
-it("Should add values to the cache", () => {
+it("Should add value to the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");
@@ -26,7 +26,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should add value to the cache and then remove it", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.1.ts
+++ b/src/11-record.solution.1.ts
@@ -18,7 +18,7 @@ const createCache = () => {
   };
 };
 
-it("Should add values to the cache", () => {
+it("Should add value to the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");
@@ -26,7 +26,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should add value to the cache and then remove it", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.2.ts
+++ b/src/11-record.solution.2.ts
@@ -20,7 +20,7 @@ const createCache = () => {
   };
 };
 
-it("Should add values to the cache", () => {
+it("Should add value to the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");
@@ -28,7 +28,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should add value to the cache and then remove it", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");

--- a/src/11-record.solution.3.ts
+++ b/src/11-record.solution.3.ts
@@ -22,7 +22,7 @@ const createCache = () => {
   };
 };
 
-it("Should add values to the cache", () => {
+it("Should add value to the cache", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");
@@ -30,7 +30,7 @@ it("Should add values to the cache", () => {
   expect(cache.cache["123"]).toEqual("Matt");
 });
 
-it("Should remove values to the cache", () => {
+it("Should add value to the cache and then remove it", () => {
   const cache = createCache();
 
   cache.add("123", "Matt");


### PR DESCRIPTION
In task No. 11 I've found an issues with the it() definition. 
Mostly the 2nd was incorrect.