### PR TITLE
Speed up tests on local and on StackBlitz

### DIFF
--- a/scripts/tests/all.test.ts
+++ b/scripts/tests/all.test.ts
@@ -26,7 +26,7 @@ describe("vitest", async () => {
     let result: string;
 
     try {
-      result = execSync(`npx vitest run --reporter=json`, {
+      result = execSync(`npx vitest run --reporter=json --single-thread`, {
         cwd: rootFolder,
         stdio: "pipe",
       }).toString();


### PR DESCRIPTION
Small change that makes a huge difference for Stackblitz and somewhat improvements for local:

## Local

Before:

![image](https://github.com/total-typescript/beginners-typescript-tutorial/assets/4008156/a5a1e3f8-cb90-4d08-bc31-cabc53cfd5ac)


After:

![image](https://github.com/total-typescript/beginners-typescript-tutorial/assets/4008156/8f4247b7-30be-4fc0-aa28-e397b475a6f8)


## Stackblitz

Before:

![image](https://github.com/total-typescript/beginners-typescript-tutorial/assets/4008156/29e83233-1082-4027-ab55-c0398f059894)


After:

![image](https://github.com/total-typescript/beginners-typescript-tutorial/assets/4008156/6957e32b-478b-46c5-a57b-6045cf5815fc)

Those were run in Chrome 113.0.5672.92 on Ubuntu at https://stackblitz.com/~/github.com/total-typescript/beginners-typescript-tutorial